### PR TITLE
Closes #22

### DIFF
--- a/templates/geoext/examples/tree/panel.js
+++ b/templates/geoext/examples/tree/panel.js
@@ -183,8 +183,14 @@ function initApp() {
 
             timeSlider.on("change", function (slider, newValue, thumb, eOpts) {
                 updateTime(rgbLayer, dateLabel, newValue);
+                for (let index of indices) {
+                    updateTime(index, dateLabel, newValue);
+                }
             });
             updateTime(rgbLayer, dateLabel, TIMES.length - 1);
+            for (let index of indices) {
+                updateTime(index, dateLabel, TIMES.length - 1);
+            }
 
             let timePanel;
             if (moreThanOneFlight) {


### PR DESCRIPTION
Fixes indices not changing date correctly on multi-flight, multispectral projects. Only the last date of indices was shown, even when the date was changed.
Before:
![image](https://user-images.githubusercontent.com/23390438/85789358-13484400-b6f4-11ea-9b56-9a78de88b4ca.png)
After:
![image](https://user-images.githubusercontent.com/23390438/85789391-20653300-b6f4-11ea-9010-a020ec699966.png)
